### PR TITLE
Fixed bug in air pump

### DIFF
--- a/handlers/BeeHandler.cpp
+++ b/handlers/BeeHandler.cpp
@@ -170,10 +170,11 @@ namespace Enki
             send_multipart(socket, ca.first, "Color", "ColorVal", data);
 
             /* Publish air flow sensor */
-            Airflow airflow;
-				airflow.set_intensity (ca.second->air_flow_sensor->intensity.norm ());
-				airflow.SerializeToString (&data);
-				send_multipart (socket, ca.first, "AirFlow", "Intensity", data);
+            AirflowReading airflowReading;
+				airflowReading.set_intensity (ca.second->air_flow_sensor->intensity.norm ());
+				airflowReading.set_direction (ca.second->air_flow_sensor->intensity.angle ());
+				airflowReading.SerializeToString (&data);
+				send_multipart (socket, ca.first, "Airflow", "Reading", data);
 
             /* Publish other stuff as necessary */
         }

--- a/interactions/AirFlowSensor.cpp
+++ b/interactions/AirFlowSensor.cpp
@@ -1,8 +1,6 @@
 #include "AirFlowSensor.h"
 #include "AirPump.h"
 
-#include <stdio.h>
-
 using namespace Enki;
 
 AirFlowSensor::AirFlowSensor (double range, Enki::Robot* owner, Enki::Vector relativePosition, double relativeOrientation):
@@ -20,7 +18,6 @@ init (double dt, Enki::World* w)
 {
 	this->intensity = Vector (0, 0);
 	Component::init ();
-	printf ("AirFlowSensor::  %10p  position %3f %3f\n", this->Component::owner, this->absolutePosition.x, this->absolutePosition.y);
 }
 
 void AirFlowSensor::

--- a/interactions/AirFlowSensor.cpp
+++ b/interactions/AirFlowSensor.cpp
@@ -1,6 +1,8 @@
 #include "AirFlowSensor.h"
 #include "AirPump.h"
 
+#include <stdio.h>
+
 using namespace Enki;
 
 AirFlowSensor::AirFlowSensor (double range, Enki::Robot* owner, Enki::Vector relativePosition, double relativeOrientation):
@@ -18,6 +20,7 @@ init (double dt, Enki::World* w)
 {
 	this->intensity = Vector (0, 0);
 	Component::init ();
+	printf ("AirFlowSensor::  %10p  position %3f %3f\n", this->Component::owner, this->absolutePosition.x, this->absolutePosition.y);
 }
 
 void AirFlowSensor::

--- a/interactions/AirFlowSensor.cpp
+++ b/interactions/AirFlowSensor.cpp
@@ -3,9 +3,9 @@
 
 using namespace Enki;
 
-AirFlowSensor::AirFlowSensor (double range, Enki::Robot* owner, Enki::Vector relativePosition):
+AirFlowSensor::AirFlowSensor (double range, Enki::Robot* owner, Enki::Vector relativePosition, double relativeOrientation):
 	LocalInteraction (range, owner),
-	Component (owner, relativePosition, OMNIDIRECTIONAL)
+	Component (owner, relativePosition, relativeOrientation)
 {
 }
 
@@ -34,4 +34,11 @@ objectStep (double dt, Enki::World* w, Enki::PhysicalObject *po)
 	}
 
 	this->intensity += airPump->getAirFlowAt (this->absolutePosition);
+}
+
+void AirFlowSensor::
+finalize (double dt, Enki::World* w)
+{
+	Matrix22 rot (-this->absoluteOrientation);
+	this->intensity = rot * this->intensity;
 }

--- a/interactions/AirFlowSensor.h
+++ b/interactions/AirFlowSensor.h
@@ -35,8 +35,11 @@ namespace Enki {
 
 		 * @param relativePosition The position of this air flow sensor relative
 		 * to robot origin.
+
+		 * @param relativeOrientation Orientation of this air flow sensor relative
+		 * to robot heading.
 		 */
-		AirFlowSensor (double range, Enki::Robot* owner, Enki::Vector relativePosition);
+		AirFlowSensor (double range, Enki::Robot* owner, Enki::Vector relativePosition, double relativeOrientation);
 		/**
 		 * Destructor
 		 */
@@ -49,6 +52,11 @@ namespace Enki {
 		 * Interact with the given object only if it is an {@code AirPump} object.
 		 */
 		virtual void objectStep (double dt, Enki::World* w, Enki::PhysicalObject *po);
+		/**
+		 * Update air flow intensity to take into consideration air flow sensor
+		 * orientation.
+		 */
+		virtual void finalize (double dt, Enki::World* w);
 	};
 
 }

--- a/interactions/AirPump.cpp
+++ b/interactions/AirPump.cpp
@@ -7,9 +7,11 @@
 
 #include <limits>
 
-#include <stdio.h>
+#include <boost/math/constants/constants.hpp>
 
 #include "AirPump.h"
+
+const double pi = boost::math::constants::pi<double>();
 
 using namespace Enki;
 
@@ -29,7 +31,6 @@ void AirPump::
 init (double dt, Enki::World* w)
 {
 	Component::init ();
-	printf ("AirPump::  %10p  position %3f %3f\n", this->Component::owner, this->absolutePosition.x, this->absolutePosition.y);
 }
 
 Vector AirPump::getAirFlowAt (const Point &position) const
@@ -41,12 +42,24 @@ Vector AirPump::getAirFlowAt (const Point &position) const
 	else if (delta.norm2 () > this->LocalInteraction::r * this->LocalInteraction::r) {
 		return Vector (0, 0);
 	}
-	else if (fabs (delta.angle () - this->absoluteOrientation) > this->aperture) {
-		return Vector (0, 0);
-	}
 	else {
-		double x = intensity * cos (this->absoluteOrientation);
-		double y = intensity * sin (this->absoluteOrientation);
-		return Vector (x, y);
+		double deltangle = delta.angle ();
+		double diff = deltangle - this->absoluteOrientation;
+		while (diff > pi) {
+			diff -= 2 * pi;
+		}
+		while (diff < -pi) {
+			diff += 2 * pi;
+		}
+		if (fabs (diff) > this->aperture) {
+			return Vector (0, 0);
+		}
+		else {
+			// double x = intensity * cos (this->absoluteOrientation);
+			// double y = intensity * sin (this->absoluteOrientation);
+			double x = intensity * cos (deltangle);
+			double y = intensity * sin (deltangle);
+			return Vector (x, y);
+		}
 	}
 }

--- a/interactions/AirPump.cpp
+++ b/interactions/AirPump.cpp
@@ -7,6 +7,8 @@
 
 #include <limits>
 
+#include <stdio.h>
+
 #include "AirPump.h"
 
 using namespace Enki;
@@ -23,6 +25,12 @@ AirPump::~AirPump ()
 {
 }
 
+void AirPump::
+init (double dt, Enki::World* w)
+{
+	Component::init ();
+	printf ("AirPump::  %10p  position %3f %3f\n", this->Component::owner, this->absolutePosition.x, this->absolutePosition.y);
+}
 
 Vector AirPump::getAirFlowAt (const Point &position) const
 {

--- a/interactions/AirPump.h
+++ b/interactions/AirPump.h
@@ -73,6 +73,8 @@ namespace Enki {
 		{
 			this->intensity = v;
 		}
+
+		void init (double dt, Enki::World* w);
 	};
 }
 

--- a/interactions/AirPump.h
+++ b/interactions/AirPump.h
@@ -74,7 +74,7 @@ namespace Enki {
 			this->intensity = v;
 		}
 
-		void init (double dt, Enki::World* w);
+		virtual void init (double dt, Enki::World* w);
 	};
 }
 

--- a/playground/AssisiPlaygroundMain.cpp
+++ b/playground/AssisiPlaygroundMain.cpp
@@ -141,6 +141,16 @@ int main(int argc, char *argv[])
             "heat log file name"
             )
         (
+            "AirFlow.pump_range",
+            po::value<double> (&Casu::AIR_PUMP_RANGE),
+            "maximum range of CASU air pump"
+            )
+        (
+            "AirFlow.sensor_range",
+            po::value<double> (&Bee::AIR_FLOW_SENSOR_RANGE),
+            "maximum range of Bee air flow sensor"
+            )
+        (
             "Vibration.maximum_amplitude", 
             po::value<double> (&Casu::VIBRATION_SOURCE_MAXIMUM_AMPLITUDE),
             "maximum amplitude of vibration"

--- a/playground/Playground.cfg
+++ b/playground/Playground.cfg
@@ -12,6 +12,10 @@ maximum_amplitude = 8
 amplitude_quadratic_decay = 0
 noise = 0
 
+[AirFlow]
+pump_range = 5      # in cm
+sensor_range = 5    # in cm
+
 [Viewer]
 max_vibration = 10
 

--- a/robots/Bee.cpp
+++ b/robots/Bee.cpp
@@ -27,6 +27,7 @@ namespace Enki
 
     const Vector Bee::AIR_FLOW_SENSOR_POSITION (0, 0);
     const double Bee::AIR_FLOW_SENSOR_RANGE = 5;
+    const double Bee::AIR_FLOW_SENSOR_ORIENTATION = pi / 3;
 
     Bee::Bee(double scaleFactor) :
         DifferentialWheeled(0.4, 2, 0.0),
@@ -87,7 +88,8 @@ namespace Enki
         air_flow_sensor = new AirFlowSensor
             (Bee::AIR_FLOW_SENSOR_RANGE,
              this,
-             Bee::AIR_FLOW_SENSOR_POSITION);
+             Bee::AIR_FLOW_SENSOR_POSITION,
+             Bee::AIR_FLOW_SENSOR_ORIENTATION);
         addLocalInteraction (this->air_flow_sensor);
     }
 

--- a/robots/Bee.cpp
+++ b/robots/Bee.cpp
@@ -26,7 +26,7 @@ namespace Enki
     double Bee::SCALE_FACTOR = 1.0;
 
     const Vector Bee::AIR_FLOW_SENSOR_POSITION (0, 0);
-    const double Bee::AIR_FLOW_SENSOR_RANGE = 5;
+    /*const*/ double Bee::AIR_FLOW_SENSOR_RANGE = 5;
     const double Bee::AIR_FLOW_SENSOR_ORIENTATION = pi / 3;
 
     Bee::Bee(double scaleFactor) :

--- a/robots/Bee.cpp
+++ b/robots/Bee.cpp
@@ -27,7 +27,7 @@ namespace Enki
 
     const Vector Bee::AIR_FLOW_SENSOR_POSITION (0, 0);
     /*const*/ double Bee::AIR_FLOW_SENSOR_RANGE = 5;
-    const double Bee::AIR_FLOW_SENSOR_ORIENTATION = pi / 3;
+    const double Bee::AIR_FLOW_SENSOR_ORIENTATION = 0;
 
     Bee::Bee(double scaleFactor) :
         DifferentialWheeled(0.4, 2, 0.0),

--- a/robots/Bee.h
+++ b/robots/Bee.h
@@ -24,7 +24,7 @@ namespace Enki
 		static double SCALE_FACTOR;
 
 		static const Vector AIR_FLOW_SENSOR_POSITION;
-		static const double AIR_FLOW_SENSOR_RANGE;
+		static /*const*/ double AIR_FLOW_SENSOR_RANGE;
 		static const double AIR_FLOW_SENSOR_ORIENTATION;
 
 	public:

--- a/robots/Bee.h
+++ b/robots/Bee.h
@@ -25,6 +25,7 @@ namespace Enki
 
 		static const Vector AIR_FLOW_SENSOR_POSITION;
 		static const double AIR_FLOW_SENSOR_RANGE;
+		static const double AIR_FLOW_SENSOR_ORIENTATION;
 
 	public:
         //! Create a Bee

--- a/robots/Casu.cpp
+++ b/robots/Casu.cpp
@@ -20,11 +20,11 @@ const double pi = boost::math::constants::pi<double>();
 
 namespace Enki
 {
-    const int Casu::AIR_PUMP_QUANTITY = 5;
-    const double Casu::AIR_PUMP_DISTANCE = 2.5;
-    const double Casu::AIR_PUMP_RANGE = 5;
+    const int Casu::AIR_PUMP_QUANTITY = 1;
+    const double Casu::AIR_PUMP_DISTANCE = 0;
+    /*const*/ double Casu::AIR_PUMP_RANGE = 5;
     const double Casu::AIR_PUMP_ORIENTATION = 0;
-    const double Casu::AIR_PUMP_APERTURE = 2 * pi / (AIR_PUMP_QUANTITY / 2);
+    const double Casu::AIR_PUMP_APERTURE = 2 * pi / AIR_PUMP_QUANTITY / 2;
 
     /*const*/ double Casu::VIBRATION_SOURCE_RANGE = 100;
     const Vector Casu::VIBRATION_SOURCE_POSITION = Vector (0, 0);
@@ -176,7 +176,7 @@ namespace Enki
 
         // Add air pump actuator
         for (int i = 0; i < Casu::AIR_PUMP_QUANTITY; i++) {
-            double angle = Casu::AIR_PUMP_ORIENTATION + i * pi / Casu::AIR_PUMP_QUANTITY;
+            double angle = Casu::AIR_PUMP_ORIENTATION + i * 2 * pi / Casu::AIR_PUMP_QUANTITY;
             Vector position (Casu::AIR_PUMP_DISTANCE * cos (angle), Casu::AIR_PUMP_DISTANCE * sin (angle));
             AirPump *airPump = new AirPump
                 (Casu::AIR_PUMP_RANGE,
@@ -186,6 +186,7 @@ namespace Enki
                  Casu::AIR_PUMP_APERTURE);
             airPump->setCylindric(0, 0, -1); // Set to point object
             world_->addObject (airPump);
+            addLocalInteraction (airPump);
             this->air_pumps [i] = airPump;
         }
     }

--- a/robots/Casu.h
+++ b/robots/Casu.h
@@ -63,7 +63,7 @@ namespace Enki
        /* air pump's parameters and configuration */
        static const int AIR_PUMP_QUANTITY;
        static const double AIR_PUMP_DISTANCE;
-       static const double AIR_PUMP_RANGE;
+       static /*const*/ double AIR_PUMP_RANGE;
        static const double AIR_PUMP_ORIENTATION;
        static const double AIR_PUMP_APERTURE;
 


### PR DESCRIPTION
Absolute position of air pumps was not done in each iteration. So they were always located in the origin.
Air flow from air pumps is radial. Currently air flow intensity is a step function.
Air pump range and air flow sensor range can be set via config file or command line parameters. After tuning with the real CASU, they should be constants (and removed from the config file).