### PR TITLE
Monitor simulation time skew

### DIFF
--- a/extensions/ExtendedWorld.h
+++ b/extensions/ExtendedWorld.h
@@ -11,6 +11,7 @@
 #define __EXTENDED_WORLD_H
 
 #include <enki/PhysicalEngine.h>
+#include <boost/timer/timer.hpp>
 
 #include "PhysicSimulation.h"
 #include "ExtendedRobot.h"
@@ -28,6 +29,26 @@ namespace Enki
 	class ExtendedWorld:
 		public World
 	{
+	private:
+		/**
+		 * Rate at which we check skewness between wall clock time and
+		 * simulation time.
+		 */
+		const double SKEW_MONITOR_RATE;
+		/**
+		 * How skew must be present so that we report it.  The message is
+		 * printed in the standard error stream.
+		 */
+		const double SKEW_REPORT_THRESHOLD;
+		/**
+		 * Elapsed time since the last check on skewness between wall clock
+		 * and simulation time.
+		 */
+		double simulatedElapsedTime;
+		/**
+		 * Timer used to monitor used to measure simulation skewness.
+		 */
+		boost::timer::cpu_timer skewTimer;
 	public:
 		typedef std::vector<PhysicSimulation *> PhysicSimulations;
 		typedef PhysicSimulations::iterator PhysicSimulationsIterator;
@@ -44,7 +65,6 @@ namespace Enki
 		
 		//! All the extended objects in the world.
 		ExtendedRobots extendedRobots;
-
 		/**
 		 * Holds the total absolute time which is a sum of all values of
 		 * parameter {@code dt} of method {@code step()}.
@@ -53,16 +73,39 @@ namespace Enki
 	public:
 		/**
 		 * Construct a world with square walls, takes width and height of the
-		 * world arena in cm. */
-		ExtendedWorld (double width, double height, const Color& wallsColor = Color::gray, const World::GroundTexture& groundTexture = World::GroundTexture());
+		 * world arena in cm.
+		 *
+		 * @param skewMonitorRate Rate at which the skew monitor checks the
+		 * simulated time against wall time.  Unit is second.  By default the
+		 * rate is 1 minute.
+		 *
+		 * @param skewReportThreshold How much skew must be present in order
+		 * to print a message.  By default is 5%.
+		 */
+		ExtendedWorld (double width, double height, const Color& wallsColor = Color::gray, const World::GroundTexture& groundTexture = World::GroundTexture(), unsigned int skewMonitorRate = 60, double skewReportThreshold = 0.05);
 		/**
 		 * Construct a world with circle walls, takes radius of the world
 		 * arena in cm.
+		 *
+		 * @param skewMonitorRate Rate at which the skew monitor checks the
+		 * simulated time against wall time.  Unit is second.  By default the
+		 * rate is 1 minute.
+		 *
+		 * @param skewReportThreshold How much skew must be present in order
+		 * to print a message.  By default is 5%.
 		 */
-		ExtendedWorld (double r, const Color& wallsColor = Color::gray, const World::GroundTexture& groundTexture = World::GroundTexture());
+		ExtendedWorld (double r, const Color& wallsColor = Color::gray, const World::GroundTexture& groundTexture = World::GroundTexture(), unsigned int skewMonitorRate = 60, double skewReportThreshold = 0.05);
 		/**
-		 * Construct a world with no walls. */
-		ExtendedWorld ();
+		 * Construct a world with no walls.
+		 *
+		 * @param skewMonitorRate Rate at which the skew monitor checks the
+		 * simulated time against wall time.  Unit is second.  By default the
+		 * rate is 1 minute.
+		 *
+		 * @param skewReportThreshold How much skew must be present in order
+		 * to print a message.  By default is 5%.
+		 */
+		ExtendedWorld (unsigned int skewMonitorRate = 60, double skewReportThreshold = 0.05);
 		virtual ~ExtendedWorld ();
 		/**
 		 * Add an object to this extended world.  Checks if it is an

--- a/interactions/HeatActuatorMesh.cpp
+++ b/interactions/HeatActuatorMesh.cpp
@@ -25,7 +25,7 @@ HeatActuatorMesh::HeatActuatorMesh (
 	int numberPoints
 	):
 	HeatActuatorPointSource (owner, relativePosition, thermalResponseTime, ambientTemperature),
-	mesh (PointMesh::makeCircleMesh (radius, numberPoints))
+	mesh (PointMesh::makeCircumferenceMesh (radius, numberPoints))
 {
 }
 

--- a/interactions/WorldHeat.cpp
+++ b/interactions/WorldHeat.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 const double WorldHeat::THERMAL_DIFFUSIVITY_AIR = 1.9e-5;
 const double WorldHeat::THERMAL_DIFFUSIVITY_COPPER = 1.11e-4;
-const double HEAT_DISSIPATION = 1e-6;
+/*const*/ double WorldHeat::CELL_DISSIPATION = 1e-6;
 
 WorldHeat::
 WorldHeat (const ExtendedWorld *world, double normalHeat, double gridScale, double borderSize, double concurrencyLevel, int logRate):
@@ -123,7 +123,7 @@ computeNextState (double deltaTime)
 				 + (this->grid [this->adtIndex][x][y - 1] - currentHeat) * this->prop [x][y - 1]
 				 + (this->grid [this->adtIndex][x + 1][y] - currentHeat) * this->prop [x + 1][y]
 				 + (this->grid [this->adtIndex][x - 1][y] - currentHeat) * this->prop [x - 1][y]
-				 + (this->normalHeat - currentHeat ) * HEAT_DISSIPATION
+				 + (this->normalHeat - currentHeat ) * CELL_DISSIPATION
 				 ) * alpha
 				;
 			this->grid [nextAdtIndex][x][y] =
@@ -150,7 +150,7 @@ updateGrid (double deltaTime, int xmin, int ymin, int xmax, int ymax)
 				 + (this->grid [this->adtIndex][x][y - 1] - currentHeat) * this->prop [x][y - 1]
 				 + (this->grid [this->adtIndex][x + 1][y] - currentHeat) * this->prop [x + 1][y]
 				 + (this->grid [this->adtIndex][x - 1][y] - currentHeat) * this->prop [x - 1][y]
-				 + (this->normalHeat - currentHeat ) * HEAT_DISSIPATION
+				 + (this->normalHeat - currentHeat ) * CELL_DISSIPATION
 				 ) * alpha
 				;
 			this->grid [nextAdtIndex][x][y] =

--- a/interactions/WorldHeat.h
+++ b/interactions/WorldHeat.h
@@ -81,6 +81,11 @@ namespace Enki
 		 * Heat in enki can diffuse through copper connections between CASUs.
 		 */
 		static const double THERMAL_DIFFUSIVITY_COPPER;
+		/**
+		 * Cells loose heat directly to the outside world, not only through border
+		 * cells.
+		 */
+		static /*const*/ double CELL_DISSIPATION;
 	public:
 		WorldHeat (const ExtendedWorld *world, double normalHeat, double gridScale, double borderSize, double concurrencyLevel, int logRate = 1);
 		virtual ~WorldHeat ();

--- a/playground/AssisiPlaygroundMain.cpp
+++ b/playground/AssisiPlaygroundMain.cpp
@@ -142,6 +142,11 @@ int main(int argc, char *argv[])
             "heat log file name"
             )
         (
+            "Heat.cell_dissipation",
+            po::value<double> (&WorldHeat::CELL_DISSIPATION),
+            "heat lost by cells directly to outside world"
+            )
+        (
             "AirFlow.pump_range",
             po::value<double> (&Casu::AIR_PUMP_RANGE),
             "maximum range of CASU air pump"

--- a/playground/AssisiPlaygroundMain.cpp
+++ b/playground/AssisiPlaygroundMain.cpp
@@ -61,6 +61,11 @@ static double timerPeriod = 0.01;
  */
 static const double DELTA_TIME = .03;
 
+static unsigned int skewMonitorRate = 60;
+
+static double skewReportThreshold = 0.05;
+
+
 /**
  * Semaphore used in the headless simulation mode with an alarm to block the
  * main thread.
@@ -196,6 +201,16 @@ int main(int argc, char *argv[])
              po::value<double> (&Bee::SCALE_FACTOR),
              "bee scale factor"
              )
+        (
+             "Skew.rate",
+             po::value<unsigned int> (&skewMonitorRate),
+             "Rate at which we check skewness between real time and simulated time"
+             )
+        (
+             "Skew.threshold",
+             po::value<double> (&skewReportThreshold),
+             "Threshold to print a message because of skewness between real time and simulated time"
+             )
         ;
 
     po::variables_map vm;
@@ -220,11 +235,13 @@ int main(int argc, char *argv[])
     //texture.invertPixels(QImage::InvertRgba);
     
     world = new WorldExt (r, pub_address, sub_address,
-		Color::gray, 
-		World::GroundTexture (
-			texture.width(),
-			texture.height(),
-			(const uint32_t*) texture.constBits ()));
+        Color::gray, 
+        World::GroundTexture (
+            texture.width(),
+            texture.height(),
+            (const uint32_t*) texture.constBits ()),
+        skewMonitorRate,
+        skewReportThreshold);
 
     heatModel = new WorldHeat (world, env_temp, heat_scale, heat_border_size, parallelismLevel);
 	if (heat_log_file_name != "") {

--- a/playground/CMakeLists.txt
+++ b/playground/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(Threads)
 
 find_package(ZeroMQ REQUIRED)
 
-find_package(Boost COMPONENTS program_options filesystem system thread REQUIRED)
+find_package(Boost COMPONENTS program_options filesystem system thread timer REQUIRED)
 
 # Set up compilation of protobuffer files
 find_package(Protobuf REQUIRED)

--- a/playground/Playground.cfg
+++ b/playground/Playground.cfg
@@ -5,6 +5,7 @@ radius = 20
 env_temp = 23   # Environmantal temperature in C
 scale = 0.5     # Scale of the grid ?
 border_size = 0 # ?
+cell_dissipation = 0
 
 [Vibration]
 range = 10   # in cm
@@ -16,9 +17,15 @@ noise = 0
 pump_range = 5      # in cm
 sensor_range = 5    # in cm
 
+[Peltier]
+thermal_response = 0.3
+
 [Viewer]
 max_vibration = 10
 
 [Simulation]
 timer_period = 0.1
 parallelism_level = 1.0
+
+[Bee]
+scale_factor = 1.0

--- a/playground/WorldExt.h
+++ b/playground/WorldExt.h
@@ -35,12 +35,22 @@ namespace Enki
                                and deletes it in the destructor!
             \param pub_address The publisher will be bound to this address.
             \param sub_address The subscriber will connect to this address for data.
+         
+           \param skewMonitorRate Rate at which the skew monitor checks the
+           simulated time against wall time.  Unit is second.  By default the
+           rate is 1 minute.
+         
+           \param skewReportThreshold How much skew must be present in order
+           to print a message.  By default is 5%.
          */
         WorldExt(double r, 
                  const std::string& pub_address,
                  const std::string& sub_address,
                  const Color& wallsColor = Color::gray,
-                 const World::GroundTexture& groundTexture = World::GroundTexture());
+                 const World::GroundTexture& groundTexture = World::GroundTexture(),
+                 unsigned int skewMonitorRate = 60,
+                 double skewReportThreshold = 0.05
+                 );
 
         //! Destructor
         virtual ~WorldExt();
@@ -71,6 +81,13 @@ it must be created on the heap and should not be deleted!
         bool handleSim_(const std::string& device,
                         const std::string& command,
                         const std::string& data);
+        //! Send outgoing messages.
+        /*! 
+            Send a message with sim state bar robot state.
+
+            \arg sock Outgoing messages are written to socket sock.
+         */
+        int sendSim_(zmq::socket_t& socket);
 
         typedef std::map<std::string, ObjectHandler*> HandlerMap;
         // Robot handler pointer, one handler per robot type


### PR DESCRIPTION
I have implemented a check on simulation time versus real time.  If simulation time lags behind real time, a message is printed.  There are two parameters that control the behaviour:

* Skew.rate - check period, unit is seconds
* Skew.threahold - if the ratio between real time and simulation time is above this threshold, a message is printed in stderr