### PR TITLE
Fixed representation of peltier ring.

### DIFF
--- a/interactions/HeatActuatorMesh.cpp
+++ b/interactions/HeatActuatorMesh.cpp
@@ -25,7 +25,7 @@ HeatActuatorMesh::HeatActuatorMesh (
 	int numberPoints
 	):
 	HeatActuatorPointSource (owner, relativePosition, thermalResponseTime, ambientTemperature),
-	mesh (PointMesh::makeCircleMesh (radius, numberPoints))
+	mesh (PointMesh::makeCircumferenceMesh (radius, numberPoints))
 {
 }
 

--- a/interactions/WorldHeat.cpp
+++ b/interactions/WorldHeat.cpp
@@ -7,7 +7,7 @@ using namespace std;
 
 const double WorldHeat::THERMAL_DIFFUSIVITY_AIR = 1.9e-5;
 const double WorldHeat::THERMAL_DIFFUSIVITY_COPPER = 1.11e-4;
-const double HEAT_DISSIPATION = 1e-6;
+/*const*/ double WorldHeat::CELL_DISSIPATION = 1e-6;
 
 WorldHeat::
 WorldHeat (const ExtendedWorld *world, double normalHeat, double gridScale, double borderSize, double concurrencyLevel, int logRate):
@@ -123,7 +123,7 @@ computeNextState (double deltaTime)
 				 + (this->grid [this->adtIndex][x][y - 1] - currentHeat) * this->prop [x][y - 1]
 				 + (this->grid [this->adtIndex][x + 1][y] - currentHeat) * this->prop [x + 1][y]
 				 + (this->grid [this->adtIndex][x - 1][y] - currentHeat) * this->prop [x - 1][y]
-				 + (this->normalHeat - currentHeat ) * HEAT_DISSIPATION
+				 + (this->normalHeat - currentHeat ) * CELL_DISSIPATION
 				 ) * alpha
 				;
 			this->grid [nextAdtIndex][x][y] =
@@ -150,7 +150,7 @@ updateGrid (double deltaTime, int xmin, int ymin, int xmax, int ymax)
 				 + (this->grid [this->adtIndex][x][y - 1] - currentHeat) * this->prop [x][y - 1]
 				 + (this->grid [this->adtIndex][x + 1][y] - currentHeat) * this->prop [x + 1][y]
 				 + (this->grid [this->adtIndex][x - 1][y] - currentHeat) * this->prop [x - 1][y]
-				 + (this->normalHeat - currentHeat ) * HEAT_DISSIPATION
+				 + (this->normalHeat - currentHeat ) * CELL_DISSIPATION
 				 ) * alpha
 				;
 			this->grid [nextAdtIndex][x][y] =

--- a/interactions/WorldHeat.h
+++ b/interactions/WorldHeat.h
@@ -81,6 +81,11 @@ namespace Enki
 		 * Heat in enki can diffuse through copper connections between CASUs.
 		 */
 		static const double THERMAL_DIFFUSIVITY_COPPER;
+		/**
+		 * Cells loose heat directly to the outside world, not only through border
+		 * cells.
+		 */
+		static /*const*/ double CELL_DISSIPATION;
 	public:
 		WorldHeat (const ExtendedWorld *world, double normalHeat, double gridScale, double borderSize, double concurrencyLevel, int logRate = 1);
 		virtual ~WorldHeat ();

--- a/playground/AssisiPlaygroundMain.cpp
+++ b/playground/AssisiPlaygroundMain.cpp
@@ -142,6 +142,11 @@ int main(int argc, char *argv[])
             "heat log file name"
             )
         (
+            "Heat.cell_dissipation",
+            po::value<double> (&WorldHeat::CELL_DISSIPATION),
+            "heat lost by cells directly to outside world"
+            )
+        (
             "AirFlow.pump_range",
             po::value<double> (&Casu::AIR_PUMP_RANGE),
             "maximum range of CASU air pump"

--- a/playground/Playground.cfg
+++ b/playground/Playground.cfg
@@ -5,6 +5,7 @@ radius = 20
 env_temp = 23   # Environmantal temperature in C
 scale = 0.5     # Scale of the grid ?
 border_size = 0 # ?
+cell_dissipation = 0
 
 [Vibration]
 range = 10   # in cm
@@ -16,9 +17,15 @@ noise = 0
 pump_range = 5      # in cm
 sensor_range = 5    # in cm
 
+[Peltier]
+thermal_response = 0.3
+
 [Viewer]
 max_vibration = 10
 
 [Simulation]
 timer_period = 0.1
 parallelism_level = 1.0
+
+[Bee]
+scale_factor = 1.0


### PR DESCRIPTION
Needs calibration with real CASU: thermal response time and cell heat dissipation can be set via configuration file.